### PR TITLE
Update feature-config content in healthcare_action_engine.json

### DIFF
--- a/sample_configs/hs-base-config.json/feature_config/healthcare_action_engine.json
+++ b/sample_configs/hs-base-config.json/feature_config/healthcare_action_engine.json
@@ -1,3 +1,6 @@
 {
-    "name": "HAE"
+    "name": "HAE",
+    "type": "HealthcareActionEngine",
+    "auditProduction": false,
+    "defaultTimezone": "America/New_York"
 }


### PR DESCRIPTION
This is copied from my local hae_deploy\config\hs\hs-base-config.json.
The version in Perforce at 
  build/docker/deploy/hae_deploy/config/hs/hs-base-config.json
contains these additional lines that are either unneeded or inappropriate for public use, or both. Do you agree?

		"productionName": "HAEDEMO.HealthcareActionEngineProduction",
		"disabled": false,
		"mirror": false,
		"databaseLocation": "",
		"description": "",
		"sslConfig": "HS.Secure.Demo"
