### PR TITLE
HSIEO-9341: Remove ports & update wg version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased - 1.1.0+snapshot]
+
+### Added 
+- 
+
+### Changed
+-
+
+### Fixed
+-
+
+### Security
+-
+
+### Removed
+- Removed WEBGATEWAY_INSECURE_PORT (wont support http for containers)
+- Removed INSTANCE_WEBSERVER_PORT (wont support private web server for containers)
+
+### Deprecated
+-
+
+## [1.0.0] - 2023-09-18
 
 - initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased - 1.1.0+snapshot]
+## [1.1.0]
 
 ### Added 
 - 
 
 ### Changed
--
+- Web-gateway now uses "latest-cd" version
 
 ### Fixed
 -

--- a/sample_deploy/container.env
+++ b/sample_deploy/container.env
@@ -32,9 +32,7 @@ INSTANCE_NAME=<INSTANCE_NAME>
 # Path to find web gateway images
 WEBGATEWAY_IMAGE_PATH=containers.intersystems.com/intersystems/webgateway
 # Version for web gateway image
-WEBGATEWAY_IMAGE_VERSION=<SPECIFIC_IMAGE_VERSION>
-# External port from which INSECURE communication to web gateway is accessible
-WEBGATEWAY_INSECURE_PORT=
+WEBGATEWAY_IMAGE_VERSION=latest-cd
 # External port from which SECURE communication to web gateway is accessible
 WEBGATEWAY_SECURE_PORT=
 # IP address for web gateway. MUST be part of same subnet as NETWORK_SUBNET above
@@ -51,8 +49,6 @@ HS_IMAGE_VERSION=<SPECIFIC_IMAGE_VERSION>
 HS_INSTANCE_UNIQUE_IDENTIFIER=<YOUR_UNIQUE_IDENTIFIER>
 # External port from which INSECURE communication to instance superserver is accessible
 INSTANCE_SUPERSERVER_PORT=
-# External port from which INSECURE communication to instance private webserver is accessible
-INSTANCE_WEBSERVER_PORT=
 # External port from which ISC Agent port 2188 is mapped
 ISC_AGENT_PORT=
 # IP address for instance. MUST be part of same subnet as NETWORK_SUBNET above

--- a/sample_deploy/docker-compose.yml
+++ b/sample_deploy/docker-compose.yml
@@ -14,7 +14,6 @@ services:
     hostname: ${HOSTNAME}
     container_name: ${COMPOSE_PROJECT_NAME}-web-gateway
     ports:
-      - ${WEBGATEWAY_INSECURE_PORT:-880}:80
       - ${WEBGATEWAY_SECURE_PORT:-443}:443
     restart: "no"
     command: --ssl
@@ -33,7 +32,6 @@ services:
     container_name: ${COMPOSE_PROJECT_NAME}-instance
     ports:
       - ${INSTANCE_SUPERSERVER_PORT:-1972}:1972
-      - ${INSTANCE_WEBSERVER_PORT:-52773}:52773
       - ${ISC_AGENT_PORT:-2188}:2188
     extra_hosts:
       - ${HOSTNAME}:${HOSTNAME_IP}


### PR DESCRIPTION
- Remove: WEBGATEWAY_INSECURE_PORT (wont support http for containers)
- Remove: INSTANCE_WEBSERVER_PORT (wont support private web server for containers)
- Update: webgateway image path and name to be "latest-cd" on intersystems container registry
- Closes #12 
- Closes #14 