### PR TITLE
HSIEO-10204: Update docker-compose to use named volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Web-gateway now uses "latest-cd" version
+- Volumes at /data/hs/ and /data/iris/ are now named "hs-data" and "iris-data". New volumes will NOT be created during image swap.
 
 ### Fixed
 -

--- a/sample_deploy/docker-compose.yml
+++ b/sample_deploy/docker-compose.yml
@@ -59,9 +59,14 @@ services:
         source: ${EXTERNAL_DATA_INGESTION_DIRECTORY:-./data-ingestion/Data/}
         target: ${ISC_HS_DATA_INGESTION_DIRECTORY:-/data-ingestion/Data/}
       - type: volume
+        source: iris-data
         target: ${ISC_DATA_DIRECTORY:-/data/iris/}
       - type: volume
+        source: hs-data
         target: ${ISC_HS_DATA_DIRECTORY:-/data/hs/}
     networks:
       federated-network:
         ipv4_address: ${INSTANCE_NETWORK_IP_ADDRESS:-192.168.10.11}
+volumes:
+  iris-data:
+  hs-data:


### PR DESCRIPTION
This will fix the issue where new volumes are created (instead of using the existing volumes) during the image swap upgrade. 